### PR TITLE
Add va_end function in Operator.cpp

### DIFF
--- a/WICWIU_src/Operator.cpp
+++ b/WICWIU_src/Operator.cpp
@@ -37,6 +37,7 @@ template<typename DTYPE> int Operator<DTYPE>::Alloc(int numInput, ...) {
             m_apInput = NULL;
 
             printf("Receive NULL pointer of Operator<DTYPE> class in %s (%s %d)\n", __FUNCTION__, __FILE__, __LINE__);
+            va_end(ap);
             return FALSE;
         }
     }
@@ -218,6 +219,7 @@ template<typename DTYPE> int Operator<DTYPE>::AddEdgebetweenOperators(int numInp
             m_apInput = NULL;
 
             printf("Receive NULL pointer of Operator<DTYPE> class in %s (%s %d)\n", __FUNCTION__, __FILE__, __LINE__);
+            va_end(ap);
             return FALSE;
         }
     }


### PR DESCRIPTION
the va_end (ap) code outside the for is not executed by the return statement.
So, I add va_end (ap) in for statement.

Fixed: #3

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>